### PR TITLE
As skip_cert_check is optional, it must return 'false' instead of empty

### DIFF
--- a/assets/out
+++ b/assets/out
@@ -30,7 +30,7 @@ if [ "$debug" = "true" ]; then
 fi
 
 api=$(jq -r '.source.api //empty' < $payload)
-skip_cert_check=$(jq -r '.source.skip_cert_check //empty' < $payload)
+skip_cert_check=$(jq -r '.source.skip_cert_check //false' < $payload)
 username=$(jq -r '.source.username //empty' < $payload)
 password=$(jq -r '.source.password //empty' < $payload)
 source_org=$(jq -r '.source.org //empty' < $payload)


### PR DESCRIPTION
Considering this test
```
echo '{"source":{}}' |jq -r '.source.skip_cert_check //false'
false
```
instead of
```
echo '{"source":{}}' |jq -r '.source.skip_cert_check //empty'
```
leads to this error in cf_login function
```
/opt/resource/cf-functions.sh: line 6: $4: unbound variable
```