### PR TITLE
Do not use echo -e when processing params

### DIFF
--- a/assets/out
+++ b/assets/out
@@ -61,7 +61,7 @@ if echo $params | jq -e 'has("command")' >/dev/null; then
   params=$(jq -n --argjson params "$params" '{commands: [ $params ] }')
 fi
 
-echo -e $params | jq -c '.commands[]' | while read -r options; do
+echo "$params" | jq -c '.commands[]' | while read -r options; do
 
   command=$(echo $options | jq -r '.command')
 


### PR DESCRIPTION
Using `echo -e` would expand any escaped character (e.g. newlines: \n)
which will result in a invalid json that jq cannot parse, failing with
an error like:

   parse error: Invalid string: control characters from U+0000 through
   U+001F must be escaped at line 215, column 2

there is no reason to use echo -e, we want to process the raw params.