### PR TITLE
Add domains support to zero-downtime-push

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@ Push a single app using the [autopilot plugin](https://github.com/contraband/aut
 * `manifest`: *Required.* Path to a application manifest file.
 * `path`: *Optional.* Path to the application to push. If this isn't set then it will be read from the manifest instead.
 * `current_app_name`: *Optional.* This should be the name of the application that this will re-deploy over. If this is set the resource will perform a zero-downtime deploy.
+* `domains`: *Optional.* List of domains to bind the application to.
 * `environment_variables`: *Optional.*  Environment variable key/value pairs to add to the manifest.
 
 ```
@@ -351,6 +352,9 @@ Push a single app using the [autopilot plugin](https://github.com/contraband/aut
       manifest: path/to/manifest.yml
       path: path/to/myapp-*.jar
       current_app_name: myapp-ui
+      domains:
+      - example.com
+      - otherdomain.example.com
       environment_variables:
         key: value
         key2: value2

--- a/assets/out
+++ b/assets/out
@@ -157,6 +157,7 @@ echo -e $params | jq -c '.commands[]' | while read -r options; do
     path=$(echo $options | jq -r '.path //empty')
     current_app_name=$(echo $options | jq -r '.current_app_name //empty')
     environment_variables=$(echo $options | jq -r '.environment_variables //empty')
+    domains=$(echo $options | jq -cr '.domains //empty')
 
     if [ ! -f "$manifest" ]; then
       echo "invalid payload (manifest is not a file: $manifest)"
@@ -176,6 +177,11 @@ echo -e $params | jq -c '.commands[]' | while read -r options; do
         echo "env.$key: $value" >>"$instructions"
       fi
     done
+
+    # add the domains to the manifest
+    if [ "$domains" ]; then
+      echo "domains: $domains" >>"$instructions"
+    fi
 
     if [ -f "$instructions" ]; then
       mv "$manifest" "$manifest.original"


### PR DESCRIPTION
Allow define a list of domains to map the application route to[1].
It accepts a list of strings.